### PR TITLE
Hardcode container versions

### DIFF
--- a/workflows/SC2_illumina_pe_assembly.wdl
+++ b/workflows/SC2_illumina_pe_assembly.wdl
@@ -298,7 +298,7 @@ task align_reads {
         bootDiskSizeGb:    10
         preemptible:    0
         maxRetries:    0
-        docker:    "broadinstitute/viral-core:2.0.21"
+        docker:    "quay.io/broadinstitute/viral-core:2.2.3"
     }
 }
 

--- a/workflows/SC2_wastewater_variant_calling.wdl
+++ b/workflows/SC2_wastewater_variant_calling.wdl
@@ -203,7 +203,7 @@ task freyja_demix {
     }
 
     runtime {
-        docker: "staphb/freyja:latest"
+        docker: "staphb/freyja:1.4.7"
         memory: "32 GB"
         cpu: 8
         disks: "local-disk 200 SSD"
@@ -256,7 +256,7 @@ task freyja_aggregate {
     }
 
     runtime {
-        docker: "staphb/freyja:latest"
+        docker: "staphb/freyja:1.4.7"
         memory: "32 GB"
         cpu: 8
         disks: "local-disk 200 SSD"


### PR DESCRIPTION
Hardcode:
staphb/freyja:1.4.7
quay.io/broadinstitute/viral-core:2.2.3
quay.io/staphb/artic-ncov2019:1.3.0
