### PR TITLE
Consolidate version capture tasks and scripts

### DIFF
--- a/scripts/version_capture.py
+++ b/scripts/version_capture.py
@@ -25,6 +25,8 @@ def create_version_df(options):
 
     records.insert(0, workflow_record)
     df = pd.DataFrame(records)
+    df = df.insert(0, 'project_name', options.project_name)
+    df = df.insert(1, 'analysis_date', options.analysis_date)
     return df
 
 if __name__ == '__main__':

--- a/scripts/version_capture.py
+++ b/scripts/version_capture.py
@@ -1,0 +1,34 @@
+import argparse
+import json
+import pandas as pd
+import sys
+
+def get_options(args=sys.argv[1:]):
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--versions_json')
+    parser.add_argument('--workflow_name')
+    parser.add_argument('--workflow_version')
+    parser.add_argument('--project_name')
+    parser.add_argument('--analysis_date')
+    options = parser.parse_args(args)
+    return options
+
+def create_version_df(options):
+    with open(options.versions_json) as f:
+        records = json.load(f)['versions']
+    
+    workflow_record = {
+        'software': options.workflow_name,
+        'docker': '',  # workflow itself does not have a docker image
+        'version': options.workflow_version
+    }
+
+    records.insert(0, workflow_record)
+    df = pd.DataFrame(records)
+    return df
+
+if __name__ == '__main__':
+    options = get_options()
+    df = create_version_df(options)
+    outfile = f"version_capture_{options.workflow_name}_{options.project_name}_{options.workflow_version}.csv"
+    df.to_csv(outfile, index=False)

--- a/scripts/version_capture.py
+++ b/scripts/version_capture.py
@@ -25,8 +25,8 @@ def create_version_df(options):
 
     records.insert(0, workflow_record)
     df = pd.DataFrame(records)
-    df = df.insert(0, 'project_name', options.project_name)
-    df = df.insert(1, 'analysis_date', options.analysis_date)
+    df.insert(0, 'project_name', options.project_name)
+    df.insert(1, 'analysis_date', options.analysis_date)
     return df
 
 if __name__ == '__main__':

--- a/tasks/version_capture_task.wdl
+++ b/tasks/version_capture_task.wdl
@@ -51,11 +51,11 @@ task task_version_capture {
   VersionInfoArray versions = { "versions": version_array }
 
   command <<<
-    python ~{version_capture_py}\
+    python ~{version_capture_py} \
       --versions_json ~{write_json(versions)} \
       --workflow_name ~{workflow_name} \
       --workflow_version ~{workflow_version} \
-      --project_name ~{project_name}
+      --project_name ~{project_name} \
       --analysis_date ~{analysis_date}
   >>>
 

--- a/tasks/version_capture_task.wdl
+++ b/tasks/version_capture_task.wdl
@@ -66,6 +66,6 @@ task task_version_capture {
     memory: "1 GB"
     cpu: 1
     docker: "mchether/py3-bio:v4"
-    disks: "local-disk 10 SDD"
+    disks: "local-disk 10 SSD"
   }
 }

--- a/tasks/version_capture_task.wdl
+++ b/tasks/version_capture_task.wdl
@@ -1,5 +1,17 @@
 version 1.0
 
+struct VersionInfo {
+  String software
+  String docker
+  String version
+}
+
+# workaround cromwell bug with read_json of Array
+# https://github.com/openwdl/wdl/issues/409
+struct VersionInfoArray {
+  Array[VersionInfo] versions
+}
+
 task workflow_version_capture {
   input {
     String? timezone
@@ -8,7 +20,7 @@ task workflow_version_capture {
     description: "capture version release"
   }
   command <<<
-    Workflow_Version="v2-0-0"
+    Workflow_Version="wip-version-capture-refactor"
     ~{default='' 'export TZ=' + timezone}
     date +"%Y-%m-%d" > TODAY
     echo "$Workflow_Version" > WORKFLOW_VERSION
@@ -23,5 +35,38 @@ task workflow_version_capture {
     docker: "ubuntu:jammy"
     disks: "local-disk 10 HDD"
     dx_instance_type: "mem1_ssd1_v2_x2" 
+  }
+}
+
+task task_version_capture {
+  input {
+    Array[VersionInfo] version_array
+    String workflow_name
+    String workflow_version
+    String project_name
+    String analysis_date
+    File version_capture_py
+  }
+
+  VersionInfoArray versions = { "versions": version_array }
+
+  command <<<
+    python ~{version_capture_py}\
+      --versions_json ~{write_json(versions)} \
+      --workflow_name ~{workflow_name} \
+      --workflow_version ~{workflow_version} \
+      --project_name ~{project_name}
+      --analysis_date ~{analysis_date}
+  >>>
+
+  output {
+    File version_capture_file = "version_capture_${workflow_name}_${project_name}_${workflow_version}.csv"
+  }
+  runtime {
+    memory: "1 GB"
+    cpu: 1
+    docker: "ubuntu:jammy"
+    disks: "local-disk 10 HDD"
+    dx_instance_type: "mem1_ssd1_v2_x2"   
   }
 }

--- a/tasks/version_capture_task.wdl
+++ b/tasks/version_capture_task.wdl
@@ -65,8 +65,7 @@ task task_version_capture {
   runtime {
     memory: "1 GB"
     cpu: 1
-    docker: "ubuntu:jammy"
-    disks: "local-disk 10 HDD"
-    dx_instance_type: "mem1_ssd1_v2_x2"   
+    docker: "mchether/py3-bio:v4"
+    disks: "local-disk 10 SDD"
   }
 }

--- a/workflows/SC2_ont_assembly.wdl
+++ b/workflows/SC2_ont_assembly.wdl
@@ -273,15 +273,15 @@ task Medaka {
         File variants_index = "${sample_name}_${index_1_id}.pass.vcf.gz.tbi"
 
         VersionInfo artic_version_info = object {
-            "software": "artic",
-            "docker": docker,
-            "version": read_string("VERSION_artic")
+            software: "artic",
+            docker: docker,
+            version: read_string("VERSION_artic")
         }
 
         VersionInfo medaka_version_info = object {
-            "software": "medaka",
-            "docker": docker,
-            "version": read_string("VERSION_medaka")
+            software: "medaka",
+            docker: docker,
+            version: read_string("VERSION_medaka")
         }
     }
 
@@ -364,9 +364,9 @@ task Bam_stats {
         File cov_s_gene_amplicons_out = "${sample_name}_S_gene_depths.tsv"
         
         VersionInfo samtools_version_info = object {
-            "software": "samtools",
-            "docker": docker,
-            "version": read_string("VERSION")
+            software: "samtools",
+            docker: docker,
+            version: read_string("VERSION")
         }
     }
 

--- a/workflows/SC2_ont_assembly.wdl
+++ b/workflows/SC2_ont_assembly.wdl
@@ -511,51 +511,6 @@ task get_primer_site_variants {
     }
 }
 
-task create_version_capture_file {
-
-
-    input {
-        File version_capture_ont_assembly_py
-        String project_name
-        String guppy_version
-        String artic_version
-        String medaka_version
-        String samtools_version
-        String pyScaf_version
-        String bcftools_version
-        String analysis_date
-        String workflow_version
-    }
-
-    command <<<
-
-        python ~{version_capture_ont_assembly_py} \
-        --project_name "~{project_name}" \
-        --guppy_version "~{guppy_version}" \
-        --artic_version "~{artic_version}" \
-        --medaka_version "~{medaka_version}" \
-        --samtools_version "~{samtools_version}" \
-        --pyScaf_version "~{pyScaf_version}" \
-        --bcftools_version "~{bcftools_version}" \
-        --analysis_date "~{analysis_date}" \
-        --workflow_version "~{workflow_version}" 
-
-
-    >>>
-
-    output {
-        File version_capture_ont_assembly = 'version_capture_ont_asembly_~{project_name}_~{workflow_version}.csv'
-    }
-
-    runtime {
-
-      docker: "mchether/py3-bio:v4"
-      memory: "1 GB"
-      cpu: 4
-      disks: "local-disk 10 SSD"
-
-    }
-}
 
 task transfer {
     input {


### PR DESCRIPTION
Currently we use separate tasks and Python scripts to capture software versions and Docker containers in workflows. The goal of this pull request is to consolidate version capturing to a single generic task and script. To accomplish this, a `VersionInfo` struct is added to `version_capture_task.wdl`, and tasks will output instances of this struct with software names, docker containers, and versions. Each workflow will call `task_version_capture` with an array of the version info structs to the `version_array` variable, and this task converts the array to a JSON file that is passed into `version_capture.py` to create an output CSV file.

As a part of the pull request, `docker` is being moved to a default variable in all task inputs to reduce  duplication and with the benefit to be able to change default docker containers for testing and special cases without needing to modify the underlying WDL.

So far (as of 2024-01-04), I have added the new version capture task and script, and have tested on the SC2_ont_assembly `Medaka` and `Bam_stats` tasks. All other tasks in the repo still need to be modified.
