### PR TITLE
Medaka updates for new 10.4.1 grid chemistry

### DIFF
--- a/scripts/novel_mutations.py
+++ b/scripts/novel_mutations.py
@@ -532,6 +532,9 @@ def main():
     
     # Append full data to historical
     df_full = pd.concat([df_historical_full, df_new_full], ignore_index = True)
+    # Check for duplicates again in case samples were re-run
+    df_full = df_full.drop_duplicates(subset = ['position', 'ref_nucl', 'alt_nucl', 
+                                'collection_date', 'site_id']).reset_index(drop = True)
     
     # For concatenated new mutation data, get dates and counts
     df_new_unique = unique_counts_and_dates(df_new_full)

--- a/workflows/SC2_ont_assembly.wdl
+++ b/workflows/SC2_ont_assembly.wdl
@@ -255,7 +255,9 @@ task Medaka {
 
     command <<<
     
-        git clone https://github.com/artic-network/primer-schemes
+        wget -q -O primer-schemes.zip https://github.com/artic-network/primer-schemes/archive/e6ddb7c4a21a65e1e4ae3c21129f9d08c2cac12f.zip
+        unzip primer-schemes.zip && mv primer-schemes-* primer-schemes
+
         artic minion --medaka --medaka-model r941_min_hac_g507 --normalise 20000 --threads 8 --read-file ~{filtered_reads} --scheme-directory primer-schemes --scheme-version 5.3.2 nCoV-2019 ~{sample_name}_~{index_1_id}
         artic -v > VERSION_artic
         medaka --version | tee VERSION_medaka

--- a/workflows/SC2_ont_assembly.wdl
+++ b/workflows/SC2_ont_assembly.wdl
@@ -299,7 +299,7 @@ task exit_wdl {
 
     runtime {
         return_codes: 0
-        container: "ubuntu:latest"
+        docker: "ubuntu:latest"
     }
 }
 

--- a/workflows/SC2_ont_assembly.wdl
+++ b/workflows/SC2_ont_assembly.wdl
@@ -16,6 +16,8 @@ workflow SC2_ont_assembly {
         File    s_gene_amplicons
         String  project_name
         String  out_dir
+        Bool trim_barcodes
+        String barcode_kit
 
         # python scripts
         File    calc_percent_coverage_py
@@ -33,7 +35,9 @@ workflow SC2_ont_assembly {
     call Demultiplex {
         input:
             fastq_files = ListFastqFiles.fastq_files,
-            index_1_id = index_1_id
+            index_1_id = index_1_id,
+            barcode_kit = barcode_kit,
+            trim_barcodes = trim_barcodes
     }
 
     call Read_Filtering {
@@ -208,6 +212,8 @@ task Demultiplex {
     input {
         Array[File] fastq_files
         String index_1_id
+        String barcode_kit
+        Bool trim_barcodes
     }
 
     Int disk_size = 3 * ceil(size(fastq_files, "GB"))
@@ -218,7 +224,7 @@ task Demultiplex {
         mkdir fastq_files
         ln -s ~{sep=' ' fastq_files} fastq_files
         ls -alF fastq_files
-        guppy_barcoder --require_barcodes_both_ends --barcode_kits "SQK-NBD114-96" --fastq_out -i fastq_files -s demux_fastq
+        guppy_barcoder --require_barcodes_both_ends --barcode_kits ~{barcode_kit} --fastq_out -i fastq_files -s demux_fastq  ~{true='--enable_trim_barcodes' false='' trim_barcodes}
         ls -alF demux_fastq
     >>>
 

--- a/workflows/SC2_ont_assembly.wdl
+++ b/workflows/SC2_ont_assembly.wdl
@@ -299,6 +299,7 @@ task exit_wdl {
 
     runtime {
         return_codes: 0
+        container: "ubuntu:latest"
     }
 }
 

--- a/workflows/SC2_ont_assembly.wdl
+++ b/workflows/SC2_ont_assembly.wdl
@@ -299,10 +299,10 @@ task Medaka {
         File variants_index = "${sample_name}_${index_1_id}.pass.vcf.gz.tbi"
         String artic_version = read_string("VERSION_artic")
         String medaka_version = read_string("VERSION_medaka")
-        File raw_variants_rg1 = "${sample_name}.1.vcf"
-        File raw_variants_rg2 = "${sample_name}.2.vcf"
-        File raw_variants_merged = "${sample_name}.merged.vcf"
-        File vcf_report = "${sample_name}.vcfreport.txt"
+        File raw_variants_rg1 = "${sample_name}_${index_1_id}.1.vcf"
+        File raw_variants_rg2 = "${sample_name}_${index_1_id}.2.vcf"
+        File raw_variants_merged = "${sample_name}_${index_1_id}.merged.vcf"
+        File vcf_report = "${sample_name}_${index_1_id}.vcfreport.txt"
     }
 
     runtime {

--- a/workflows/SC2_ont_assembly.wdl
+++ b/workflows/SC2_ont_assembly.wdl
@@ -285,7 +285,6 @@ task Medaka {
         File variants_index = "${sample_name}_${index_1_id}.pass.vcf.gz.tbi"
         String artic_version = read_string("VERSION_artic")
         String medaka_version = read_string("VERSION_medaka")
-        String throw_error =
     }
 
     runtime {

--- a/workflows/SC2_ont_assembly.wdl
+++ b/workflows/SC2_ont_assembly.wdl
@@ -128,24 +128,24 @@ workflow SC2_ont_assembly {
 
     call transfer {
         input:
-        outdirpath = outdirpath,
-        trimsort_bam = select_first([medaka_strict.trimsort_bam, medaka_normal.trimsort_bam]),
-        trimsort_bai = select_first([medaka_strict.trimsort_bai, medaka_normal.trimsort_bai]),
-        flagstat_out = Bam_stats.flagstat_out,
-        samstats_out = Bam_stats.stats_out,
-        covhist_out = Bam_stats.covhist_out,
-        cov_out = Bam_stats.cov_out,
-        depth_out = Bam_stats.depth_out,
-        cov_s_gene_out = Bam_stats.cov_s_gene_out,
-        cov_s_gene_amplicons_out = Bam_stats.cov_s_gene_amplicons_out,
-        variants = select_first([medaka_strict.variants, medaka_normal.variants]),
-        renamed_consensus = rename_fasta.renamed_consensus,
-        primer_site_variants = get_primer_site_variants.primer_site_variants,
-        version_capture_ont_assembly = create_version_capture_file.version_capture_ont_assembly,
-        raw_variants_rg1 = select_first([medaka_strict.raw_variants_rg1, medaka_normal.raw_variants_rg1]),
-        raw_variants_rg2 = select_first([medaka_strict.raw_variants_rg2, medaka_normal.raw_variants_rg2]),
-        raw_variants_merged = select_first([medaka_strict.raw_variants_merged, medaka_normal.raw_variants_merged]),
-        vcf_report = select_first([medaka_strict.vcf_report, medaka_normal.vcf_report])
+            outdirpath = outdirpath,
+            trimsort_bam = select_first([medaka_strict.trimsort_bam, medaka_normal.trimsort_bam]),
+            trimsort_bai = select_first([medaka_strict.trimsort_bai, medaka_normal.trimsort_bai]),
+            flagstat_out = Bam_stats.flagstat_out,
+            samstats_out = Bam_stats.stats_out,
+            covhist_out = Bam_stats.covhist_out,
+            cov_out = Bam_stats.cov_out,
+            depth_out = Bam_stats.depth_out,
+            cov_s_gene_out = Bam_stats.cov_s_gene_out,
+            cov_s_gene_amplicons_out = Bam_stats.cov_s_gene_amplicons_out,
+            variants = select_first([medaka_strict.variants, medaka_normal.variants]),
+            renamed_consensus = rename_fasta.renamed_consensus,
+            primer_site_variants = get_primer_site_variants.primer_site_variants,
+            version_capture_ont_assembly = create_version_capture_file.version_capture_ont_assembly,
+            raw_variants_rg1 = select_first([medaka_strict.raw_variants_rg1, medaka_normal.raw_variants_rg1]),
+            raw_variants_rg2 = select_first([medaka_strict.raw_variants_rg2, medaka_normal.raw_variants_rg2]),
+            raw_variants_merged = select_first([medaka_strict.raw_variants_merged, medaka_normal.raw_variants_merged]),
+            vcf_report = select_first([medaka_strict.vcf_report, medaka_normal.vcf_report])
 
     }
 
@@ -283,7 +283,7 @@ task Medaka {
 
     command <<<
 
-       artic minion --medaka --medaka-model r941_min_hac_g507 ~{true='--strict' false='' strict} --normalise 20000 --threads 8 --read-file ~{filtered_reads} nCoV-2019 ~{sample_name}_~{index_1_id}
+        artic minion --medaka --medaka-model r941_min_hac_g507 ~{true='--strict' false='' strict} --normalise 20000 --threads 8 --read-file ~{filtered_reads} nCoV-2019 ~{sample_name}_~{index_1_id}
 
         artic -v > VERSION_artic
         medaka --version | tee VERSION_medaka
@@ -587,6 +587,10 @@ task transfer {
         File renamed_consensus
         File primer_site_variants
         File version_capture_ont_assembly
+        File raw_variants_rg1
+        File raw_variants_rg2
+        File raw_variants_merged
+        File vcf_report
 
     }
 

--- a/workflows/SC2_ont_assembly.wdl
+++ b/workflows/SC2_ont_assembly.wdl
@@ -145,6 +145,7 @@ workflow SC2_ont_assembly {
             raw_variants_rg1 = select_first([medaka_strict.raw_variants_rg1, medaka_normal.raw_variants_rg1]),
             raw_variants_rg2 = select_first([medaka_strict.raw_variants_rg2, medaka_normal.raw_variants_rg2]),
             raw_variants_merged = select_first([medaka_strict.raw_variants_merged, medaka_normal.raw_variants_merged]),
+            vcf_report = select_first([medaka_strict.vcf_report, medaka_normal.vcf_report])
 
     }
 
@@ -175,6 +176,7 @@ workflow SC2_ont_assembly {
         File raw_variants_rg1 = select_first([medaka_strict.raw_variants_rg1, medaka_normal.raw_variants_rg1])
         File raw_variants_rg2 = select_first([medaka_strict.raw_variants_rg2, medaka_normal.raw_variants_rg2])
         File raw_variants_merged = select_first([medaka_strict.raw_variants_merged, medaka_normal.raw_variants_merged])
+        File vcf_report = select_first([medaka_strict.vcf_report, medaka_normal.vcf_report])
     }
 }
 
@@ -300,6 +302,7 @@ task Medaka {
         File raw_variants_rg1 = "${sample_name}.1.vcf"
         File raw_variants_rg2 = "${sample_name}.2.vcf"
         File raw_variants_merged = "${sample_name}.merged.vcf"
+        File vcf_report = "${sample_name}.vcfreport.txt"
     }
 
     runtime {
@@ -587,6 +590,7 @@ task transfer {
         File raw_variants_rg1
         File raw_variants_rg2
         File raw_variants_merged
+        File vcf_report
 
     }
 
@@ -613,6 +617,7 @@ task transfer {
         gsutil -m cp ~{raw_variants_rg1} ~{outdirpath}/alignments/
         gsutil -m cp ~{raw_variants_rg2} ~{outdirpath}/alignments/
         gsutil -m cp ~{raw_variants_merged} ~{outdirpath}/alignments/
+        gsutil -m cp ~{vcf_report} ~{outdirpath}/alignments/
 
     >>>
 

--- a/workflows/SC2_ont_assembly.wdl
+++ b/workflows/SC2_ont_assembly.wdl
@@ -16,7 +16,7 @@ workflow SC2_ont_assembly {
         File    s_gene_amplicons
         String  project_name
         String  out_dir
-        Bool trim_barcodes
+        Boolean trim_barcodes
         String barcode_kit
 
         # python scripts
@@ -213,7 +213,7 @@ task Demultiplex {
         Array[File] fastq_files
         String index_1_id
         String barcode_kit
-        Bool trim_barcodes
+        Boolean trim_barcodes
     }
 
     Int disk_size = 3 * ceil(size(fastq_files, "GB"))

--- a/workflows/SC2_ont_assembly.wdl
+++ b/workflows/SC2_ont_assembly.wdl
@@ -281,7 +281,7 @@ task Medaka {
 
     command <<<
 
-        artic minion --medaka --medaka-model r941_min_hac_g507 ~{true='--strict' false='' strict} --normalise 20000 --threads 8 --read-file ~{filtered_reads} nCoV-2019 ~{sample_name}_~{index_1_id}
+        artic minion --medaka --medaka-model r1041_e82_400bps_hac_v4.2.0 ~{true='--strict' false='' strict} --normalise 20000 --threads 8 --read-file ~{filtered_reads} nCoV-2019 ~{sample_name}_~{index_1_id}
 
         artic -v > VERSION_artic
         medaka --version | tee VERSION_medaka

--- a/workflows/SC2_ont_assembly.wdl
+++ b/workflows/SC2_ont_assembly.wdl
@@ -145,7 +145,6 @@ workflow SC2_ont_assembly {
             raw_variants_rg1 = select_first([medaka_strict.raw_variants_rg1, medaka_normal.raw_variants_rg1]),
             raw_variants_rg2 = select_first([medaka_strict.raw_variants_rg2, medaka_normal.raw_variants_rg2]),
             raw_variants_merged = select_first([medaka_strict.raw_variants_merged, medaka_normal.raw_variants_merged]),
-            vcf_report = select_first([medaka_strict.vcf_report, medaka_normal.vcf_report])
 
     }
 
@@ -176,7 +175,6 @@ workflow SC2_ont_assembly {
         File raw_variants_rg1 = select_first([medaka_strict.raw_variants_rg1, medaka_normal.raw_variants_rg1])
         File raw_variants_rg2 = select_first([medaka_strict.raw_variants_rg2, medaka_normal.raw_variants_rg2])
         File raw_variants_merged = select_first([medaka_strict.raw_variants_merged, medaka_normal.raw_variants_merged])
-        File vcf_report = select_first([medaka_strict.vcf_report, medaka_normal.vcf_report])
     }
 }
 
@@ -302,7 +300,6 @@ task Medaka {
         File raw_variants_rg1 = "${sample_name}_${index_1_id}.1.vcf"
         File raw_variants_rg2 = "${sample_name}_${index_1_id}.2.vcf"
         File raw_variants_merged = "${sample_name}_${index_1_id}.merged.vcf"
-        File vcf_report = "${sample_name}_${index_1_id}.vcfreport.txt"
     }
 
     runtime {
@@ -590,8 +587,6 @@ task transfer {
         File raw_variants_rg1
         File raw_variants_rg2
         File raw_variants_merged
-        File vcf_report
-
     }
 
     command <<<
@@ -617,7 +612,6 @@ task transfer {
         gsutil -m cp ~{raw_variants_rg1} ~{outdirpath}/alignments/
         gsutil -m cp ~{raw_variants_rg2} ~{outdirpath}/alignments/
         gsutil -m cp ~{raw_variants_merged} ~{outdirpath}/alignments/
-        gsutil -m cp ~{vcf_report} ~{outdirpath}/alignments/
 
     >>>
 

--- a/workflows/SC2_ont_assembly.wdl
+++ b/workflows/SC2_ont_assembly.wdl
@@ -218,7 +218,7 @@ task Demultiplex {
         mkdir fastq_files
         ln -s ~{sep=' ' fastq_files} fastq_files
         ls -alF fastq_files
-        guppy_barcoder --require_barcodes_both_ends --barcode_kits "EXP-NBD196" --fastq_out -i fastq_files -s demux_fastq
+        guppy_barcoder --require_barcodes_both_ends --barcode_kits "SQK-NBD114-96" --fastq_out -i fastq_files -s demux_fastq
         ls -alF demux_fastq
     >>>
 
@@ -234,7 +234,7 @@ task Demultiplex {
         disks:    "local-disk 100 SSD"
         preemptible:    0
         maxRetries:    3
-        docker:    "genomicpariscentre/guppy:latest"
+        docker:    "genomicpariscentre/guppy:6.4.6"
     }
 }
 

--- a/workflows/SC2_ont_assembly.wdl
+++ b/workflows/SC2_ont_assembly.wdl
@@ -142,7 +142,6 @@ workflow SC2_ont_assembly {
         renamed_consensus = rename_fasta.renamed_consensus,
         primer_site_variants = get_primer_site_variants.primer_site_variants,
         version_capture_ont_assembly = create_version_capture_file.version_capture_ont_assembly,
-
         raw_variants_rg1 = select_first([medaka_strict.raw_variants_rg1, medaka_normal.raw_variants_rg1]),
         raw_variants_rg2 = select_first([medaka_strict.raw_variants_rg2, medaka_normal.raw_variants_rg2]),
         raw_variants_merged = select_first([medaka_strict.raw_variants_merged, medaka_normal.raw_variants_merged]),

--- a/workflows/SC2_ont_assembly.wdl
+++ b/workflows/SC2_ont_assembly.wdl
@@ -273,7 +273,7 @@ task Medaka {
 
     command <<<
 
-       artic minion --medaka --medaka-model r941_min_high_g360 ~{true='--strict' false='' strict} --normalise 20000 --threads 8 --read-file ~{filtered_reads} ~{sample_name}_~{index_1_id}
+       artic minion --medaka --medaka-model r941_min_high_g360 ~{true='--strict' false='' strict} --normalise 20000 --threads 8 --read-file ~{filtered_reads} nCoV-2019 ~{sample_name}_~{index_1_id}
 
         artic -v > VERSION_artic
         medaka --version | tee VERSION_medaka

--- a/workflows/SC2_ont_assembly.wdl
+++ b/workflows/SC2_ont_assembly.wdl
@@ -273,10 +273,7 @@ task Medaka {
 
     command <<<
 
-        wget -q -O primer-schemes.zip https://github.com/artic-network/primer-schemes/archive/e6ddb7c4a21a65e1e4ae3c21129f9d08c2cac12f.zip
-        unzip primer-schemes.zip && mv primer-schemes-* primer-schemes
-
-        artic minion --medaka --medaka-model r941_min_hac_g507 ~{true='--strict' false='' strict} --normalise 20000 --threads 8 --read-file ~{filtered_reads} --scheme-directory primer-schemes --scheme-version 5.3.2 nCoV-2019 ~{sample_name}_~{index_1_id}
+       artic minion --medaka --medaka-model r941_min_high_g360 ~{true='--strict' false='' strict} --normalise 20000 --threads 8 --read-file ~{filtered_reads} ~{sample_name}_~{index_1_id}
 
         artic -v > VERSION_artic
         medaka --version | tee VERSION_medaka

--- a/workflows/SC2_ont_assembly.wdl
+++ b/workflows/SC2_ont_assembly.wdl
@@ -145,7 +145,6 @@ workflow SC2_ont_assembly {
             raw_variants_rg1 = select_first([medaka_strict.raw_variants_rg1, medaka_normal.raw_variants_rg1]),
             raw_variants_rg2 = select_first([medaka_strict.raw_variants_rg2, medaka_normal.raw_variants_rg2]),
             raw_variants_merged = select_first([medaka_strict.raw_variants_merged, medaka_normal.raw_variants_merged]),
-            vcf_report = select_first([medaka_strict.vcf_report, medaka_normal.vcf_report])
 
     }
 
@@ -176,7 +175,6 @@ workflow SC2_ont_assembly {
         File raw_variants_rg1 = select_first([medaka_strict.raw_variants_rg1, medaka_normal.raw_variants_rg1])
         File raw_variants_rg2 = select_first([medaka_strict.raw_variants_rg2, medaka_normal.raw_variants_rg2])
         File raw_variants_merged = select_first([medaka_strict.raw_variants_merged, medaka_normal.raw_variants_merged])
-        File vcf_report = select_first([medaka_strict.vcf_report, medaka_normal.vcf_report])
     }
 }
 
@@ -302,7 +300,6 @@ task Medaka {
         File raw_variants_rg1 = "${sample_name}.1.vcf"
         File raw_variants_rg2 = "${sample_name}.2.vcf"
         File raw_variants_merged = "${sample_name}.merged.vcf"
-        File vcf_report = "${sample_name}.vcfreport.txt"
     }
 
     runtime {
@@ -590,7 +587,6 @@ task transfer {
         File raw_variants_rg1
         File raw_variants_rg2
         File raw_variants_merged
-        File vcf_report
 
     }
 
@@ -617,7 +613,6 @@ task transfer {
         gsutil -m cp ~{raw_variants_rg1} ~{outdirpath}/alignments/
         gsutil -m cp ~{raw_variants_rg2} ~{outdirpath}/alignments/
         gsutil -m cp ~{raw_variants_merged} ~{outdirpath}/alignments/
-        gsutil -m cp ~{vcf_report} ~{outdirpath}/alignments/
 
     >>>
 

--- a/workflows/SC2_ont_assembly.wdl
+++ b/workflows/SC2_ont_assembly.wdl
@@ -57,7 +57,11 @@ workflow SC2_ont_assembly {
         Boolean empty_fasta = if (consensus_size < 30) then true else false
 
         if (empty_fasta) {
-            call exit_wdl
+            String exit_reason = "Empty fasta"
+            call exit_wdl {
+                input:
+                    exit_reason = exit_reason
+            }
         }
     }
 
@@ -293,7 +297,12 @@ task Medaka {
 }
 
 task exit_wdl {
+    input {
+        String exit_reason
+    }
+    
     command <<<
+        echo "~{exit_reason}"
         exit 1
     >>>
 

--- a/workflows/SC2_ont_assembly.wdl
+++ b/workflows/SC2_ont_assembly.wdl
@@ -258,7 +258,7 @@ task Medaka {
         wget -q -O primer-schemes.zip https://github.com/artic-network/primer-schemes/archive/e6ddb7c4a21a65e1e4ae3c21129f9d08c2cac12f.zip
         unzip primer-schemes.zip && mv primer-schemes-* primer-schemes
 
-        artic minion --medaka --medaka-model r941_min_hac_g507 --normalise 20000 --threads 8 --read-file ~{filtered_reads} --scheme-directory primer-schemes --scheme-version 5.3.2 nCoV-2019 ~{sample_name}_~{index_1_id}
+        artic minion --medaka --medaka-model r941_min_hac_g507 --strict --normalise 20000 --threads 8 --read-file ~{filtered_reads} --scheme-directory primer-schemes --scheme-version 5.3.2 nCoV-2019 ~{sample_name}_~{index_1_id}
         artic -v > VERSION_artic
         medaka --version | tee VERSION_medaka
 

--- a/workflows/SC2_ont_assembly.wdl
+++ b/workflows/SC2_ont_assembly.wdl
@@ -274,7 +274,7 @@ task Medaka {
     }
 
     runtime {
-        docker: "quay.io/staphb/artic-ncov2019:1.3.0"
+        docker: "staphb/artic:1.2.4-1.11.1"
         memory: "16 GB"
         cpu: 8
         disks: "local-disk 100 SSD"

--- a/workflows/SC2_ont_assembly.wdl
+++ b/workflows/SC2_ont_assembly.wdl
@@ -276,7 +276,7 @@ task Medaka {
         wget -q -O primer-schemes.zip https://github.com/artic-network/primer-schemes/archive/e6ddb7c4a21a65e1e4ae3c21129f9d08c2cac12f.zip
         unzip primer-schemes.zip && mv primer-schemes-* primer-schemes
 
-        artic minion --medaka --medaka-model r941_min_hac_g507 "~{true='--strict' false='' strict}" --normalise 20000 --threads 8 --read-file ~{filtered_reads} --scheme-directory primer-schemes --scheme-version 5.3.2 nCoV-2019 ~{sample_name}_~{index_1_id}
+        artic minion --medaka --medaka-model r941_min_hac_g507 ~{true='--strict' false='' strict} --normalise 20000 --threads 8 --read-file ~{filtered_reads} --scheme-directory primer-schemes --scheme-version 5.3.2 nCoV-2019 ~{sample_name}_~{index_1_id}
 
         artic -v > VERSION_artic
         medaka --version | tee VERSION_medaka

--- a/workflows/SC2_ont_assembly.wdl
+++ b/workflows/SC2_ont_assembly.wdl
@@ -100,7 +100,7 @@ workflow SC2_ont_assembly {
             project_name = project_name, 
             guppy_version = Demultiplex.guppy_version,
             artic_version = Medaka.artic_version,
-            medaka_version = Medaka.nanopolish_version,
+            medaka_version = Medaka.medaka_version,
             samtools_version = Bam_stats.samtools_version,
             pyScaf_version = Scaffold.pyScaf_version,
             bcftools_version = get_primer_site_variants.bcftools_version,
@@ -258,9 +258,9 @@ task Medaka {
         wget -q -O primer-schemes.zip https://github.com/artic-network/primer-schemes/archive/e6ddb7c4a21a65e1e4ae3c21129f9d08c2cac12f.zip
         unzip primer-schemes.zip && mv primer-schemes-* primer-schemes
 
-        artic minion --normalise 20000 --threads 8 --read-file ~{filtered_reads} --scheme-directory primer-schemes --scheme-version 5.3.2 nCoV-2019 ~{sample_name}_~{index_1_id}
+        artic minion --medaka --medaka-model r941_min_hac_g507 --strict --normalise 20000 --threads 8 --read-file ~{filtered_reads} --scheme-directory primer-schemes --scheme-version 5.3.2 nCoV-2019 ~{sample_name}_~{index_1_id}
         artic -v > VERSION_artic
-        nanopolish --version | tee VERSION_nanopolish
+        medaka --version | tee VERSION_medaka
 
     >>>
 
@@ -272,7 +272,7 @@ task Medaka {
         File variants = "${sample_name}_${index_1_id}.pass.vcf.gz"
         File variants_index = "${sample_name}_${index_1_id}.pass.vcf.gz.tbi"
         String artic_version = read_string("VERSION_artic")
-        String nanopolish_version = read_string("VERSION_nanopolish")
+        String medaka_version = read_string("VERSION_medaka")
     }
 
     runtime {
@@ -503,7 +503,7 @@ task create_version_capture_file {
         String project_name
         String guppy_version
         String artic_version
-        String nanopolish_version
+        String medaka_version
         String samtools_version
         String pyScaf_version
         String bcftools_version
@@ -517,7 +517,7 @@ task create_version_capture_file {
         --project_name "~{project_name}" \
         --guppy_version "~{guppy_version}" \
         --artic_version "~{artic_version}" \
-        --nanopolish_version "~{nanopolish_version}" \
+        --medaka_version "~{medaka_version}" \
         --samtools_version "~{samtools_version}" \
         --pyScaf_version "~{pyScaf_version}" \
         --bcftools_version "~{bcftools_version}" \

--- a/workflows/SC2_ont_assembly.wdl
+++ b/workflows/SC2_ont_assembly.wdl
@@ -100,7 +100,7 @@ workflow SC2_ont_assembly {
             project_name = project_name, 
             guppy_version = Demultiplex.guppy_version,
             artic_version = Medaka.artic_version,
-            medaka_version = Medaka.medaka_version,
+            medaka_version = Medaka.nanopolish_version,
             samtools_version = Bam_stats.samtools_version,
             pyScaf_version = Scaffold.pyScaf_version,
             bcftools_version = get_primer_site_variants.bcftools_version,
@@ -258,9 +258,9 @@ task Medaka {
         wget -q -O primer-schemes.zip https://github.com/artic-network/primer-schemes/archive/e6ddb7c4a21a65e1e4ae3c21129f9d08c2cac12f.zip
         unzip primer-schemes.zip && mv primer-schemes-* primer-schemes
 
-        artic minion --medaka --medaka-model r941_min_hac_g507 --strict --normalise 20000 --threads 8 --read-file ~{filtered_reads} --scheme-directory primer-schemes --scheme-version 5.3.2 nCoV-2019 ~{sample_name}_~{index_1_id}
+        artic minion --normalise 20000 --threads 8 --read-file ~{filtered_reads} --scheme-directory primer-schemes --scheme-version 5.3.2 nCoV-2019 ~{sample_name}_~{index_1_id}
         artic -v > VERSION_artic
-        medaka --version | tee VERSION_medaka
+        nanopolish --version | tee VERSION_nanopolish
 
     >>>
 
@@ -272,7 +272,7 @@ task Medaka {
         File variants = "${sample_name}_${index_1_id}.pass.vcf.gz"
         File variants_index = "${sample_name}_${index_1_id}.pass.vcf.gz.tbi"
         String artic_version = read_string("VERSION_artic")
-        String medaka_version = read_string("VERSION_medaka")
+        String nanopolish_version = read_string("VERSION_nanopolish")
     }
 
     runtime {
@@ -503,7 +503,7 @@ task create_version_capture_file {
         String project_name
         String guppy_version
         String artic_version
-        String medaka_version
+        String nanopolish_version
         String samtools_version
         String pyScaf_version
         String bcftools_version
@@ -517,7 +517,7 @@ task create_version_capture_file {
         --project_name "~{project_name}" \
         --guppy_version "~{guppy_version}" \
         --artic_version "~{artic_version}" \
-        --medaka_version "~{medaka_version}" \
+        --nanopolish_version "~{nanopolish_version}" \
         --samtools_version "~{samtools_version}" \
         --pyScaf_version "~{pyScaf_version}" \
         --bcftools_version "~{bcftools_version}" \


### PR DESCRIPTION
## Overview

Update Medaka task for new grid 10.4.1 chemistry.

## Updates

Task | Section | Previous | Updated
| -- | -- | -- | -- |
Demultiplex | barcode kit | EXP-NBD196 | SQK-NBD114-96
Demultiplex | task container version | latest | 6.4.6
Medaka | model | r941_min_high_g360 | r1041_e82_400bps_hac_v4.2.0
Medaka | container | [quay.io/staphb/artic-ncov2019:1.3.0](https://quay.io/staphb/artic-ncov2019:1.3.0) | [quay.io/staphb/artic/1.2.4-1.11.1](https://quay.io/staphb/artic/1.2.4-1.11.1)

#### New task - exit_wdl
- Input: string exit_reason (declared in the script, no input changes needed)
- This task will automatically error out when called by utilizing the runtime return_codes attribute.
- We could make this a task we import and use it to exit in other workflows for other reasons if needed.

## Known issue
### Problem
See [issue](https://github.com/artic-network/fieldbioinformatics/issues/132) created in artic-network.

### Solution
Check the size of the fasta file generated. If under 30B, then fail the sample. A new task, exit_wdl, was written to accomplish this.

## Upstream/downstream changes needed
None :)

## Changes needed on user end
None :)