### PR TITLE
Novel mutations - ORF1ab, other updates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,28 @@
+---
+name: Bug report
+about: "[BUG]"
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: "[REQUEST]"
+title: ''
+labels: request
+assignees: ''
+
+---
+
+### Feature Request
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+### Solution
+A clear and concise description of what you want to happen.
+
+### Upstream effects
+Add any upstream effects required if this change is implemented.
+
+### Downstream effects
+Add any downstream effects to be aware of if this change is implemented.

--- a/.github/ISSUE_TEMPLATE/requirement.md
+++ b/.github/ISSUE_TEMPLATE/requirement.md
@@ -1,0 +1,23 @@
+---
+name: Requirement
+about: "[REQUIREMENT]"
+title: ''
+labels: requirement
+assignees: ''
+
+---
+
+### Need-by date
+Anticipated date (YYYY-MM-DD)
+
+### Feature Request
+A clear and concise description of what the problem is. 
+
+### Solution
+A clear and concise description of what you want to happen.
+
+### Upstream effects
+Add any upstream effects required if this change is implemented.
+
+### Downstream effects
+Add any downstream effects to be aware of if this change is implemented.

--- a/scripts/novel_mutations.py
+++ b/scripts/novel_mutations.py
@@ -98,7 +98,7 @@ def get_parent(position, feature):
     
     # Return other info for ORF1ab since outbreak.info separates them into 
     # ORF1a and ORF1b instead of ensembl's ORF1ab and ORF1a
-    if feature == 'cds-YP_009725295.1' or feature == 'cds-YP_009724389.1': #ORF1a
+    if feature == 'cds-YP_009725295.1' or feature == 'cds-YP_009724389.1':
         if position <= 13468:
             d = ['ORF1a polyprotein', 'gene-GU280_gp01', 'ORF1a', 266, 13468]
         else:

--- a/scripts/novel_mutations.py
+++ b/scripts/novel_mutations.py
@@ -34,25 +34,23 @@ def parse_arguments(args = sys.argv[1:]):
 
 
 def read_reference_files(historical_full, historical_unique, metadata, gff):
-   
-    df_historical_full = pd.read_csv(historical_full, sep = '\t', 
-                         parse_dates = ['collection_date'], 
-                         dtype = {'sample_name' : 'category', 
-                                  'sample_name_base' : 'category'})
-    df_historical_unique = pd.read_csv(historical_unique, sep = '\t', 
-                           parse_dates = ['date_first_detected', 'date_last_detected'])
     df_metadata = pd.read_csv(metadata, sep = '\t', parse_dates = ['collection_date'])
     df_gff = pd.read_csv(gff, sep = '\t')
     
-    # Change some columns to categorical to decrease memory usage
-    hist_category_cols = ['ref_nucl', 'alt_nucl', 'ref_aa', 'alt_aa', 
-                          'gff_feature', 'site_id']
-    df_historical_full[hist_category_cols] = df_historical_full[hist_category_cols].astype('category')
+    # Read in some columns as categorical to decrease memory usage
+    hist_category_cols = ['sample_name', 'sample_name_base', 'ref_nucl', 
+                          'alt_nucl', 'ref_aa', 'alt_aa', 'gff_feature', 'site_id']
+    df_historical_full = pd.read_csv(historical_full, sep = '\t', 
+                         parse_dates = ['collection_date'], 
+                         dtype = dict.fromkeys(hist_category_cols, 'category'))
     
-    hist_category_cols = hist_category_cols[:-1]
+
+    hist_category_cols = hist_category_cols[2:-1]
     hist_category_cols.extend(['mutation_type', 'id_return', 'parent_id', 'parent', 
                                'parent_start', 'parent_end', 'indel_length'])
-    df_historical_unique[hist_category_cols] = df_historical_unique[hist_category_cols].astype('category')
+    df_historical_unique = pd.read_csv(historical_unique, sep = '\t', 
+                           parse_dates = ['date_first_detected', 'date_last_detected'],
+                           dtype = dict.fromkeys(hist_category_cols, 'category'))
         
     return df_historical_full, df_historical_unique, df_metadata, df_gff
 


### PR DESCRIPTION
## Overview
Updates to novel_mutations.py. There were not any changes needed after the sample name switch to HSNs. Closes #14. 

## Updates
1. ORF1ab gene coordinate/parent information
    - outbreak.info separates ORF1ab into ORF1a and ORF1b, with a start/end overlap at 134268. This contradicts the information in ensembl's gff file, which includes ORF1a and ORF1ab. The code was updated to match the outbreak.info notation.
2. Bug fix on sites_to_drop
    - Fixed list length check to >0 instead of >1.
3. Update read_csv dtypes for efficiency.
4. Small documentation updates.

## Upstream/downstream changes needed
None :)

## Changes needed on user end
None :)













