### PR TITLE
Wip cdc variant url

### DIFF
--- a/scripts/concat_seq_metrics_and_lineage_results.py
+++ b/scripts/concat_seq_metrics_and_lineage_results.py
@@ -9,6 +9,8 @@ import sys
 import pandas as pd
 from datetime import date
 import re
+import requests
+import json
 
 ###### URLs ########
 
@@ -487,7 +489,7 @@ def format_pangolin_df(pangolin_lineage_csv, cdc_groupings_df):
 
     # determine  aggregrated lineage by using the expanded lineage column in pangolin df
     aggregated_lineage_df = pangolin[['expanded_lineage']].copy()
-    aggregated_lineage_df['aggregrated_lineage'] = aggregated_lineage_df.apply(lambda x:get_cdc_grouping(x.expanded_lineage, cdc_groupings_df), axis = 1 )
+    aggregated_lineage_df['aggregated_lineage'] = aggregated_lineage_df.apply(lambda x:get_cdc_grouping(x.expanded_lineage, cdc_groupings_df), axis = 1 )
     aggregated_lineage_df.drop('expanded_lineage', axis=1, inplace=True)
 
     return pangolin, aggregated_lineage_df
@@ -617,8 +619,7 @@ if __name__ == '__main__':
     cdc_groupings_df = generate_cdc_groupings_df(cdc_groupings = cdc_groupings,
                                                  pango_alias_key = pango_alias_key)
     pangolin_df, aggregated_lineage_df = format_pangolin_df(pangolin_lineage_csv = pangolin_lineage_csv,
-                                  cdc_groupings_df = cdc_groupings_df,
-                                  pango_alias_key = pango_alias_key)
+                                  cdc_groupings_df = cdc_groupings_df)
 
     # create results file
     results_df = concat_results(sample_name_list = sample_name_list,

--- a/tasks/version_capture_task.wdl
+++ b/tasks/version_capture_task.wdl
@@ -20,7 +20,7 @@ task workflow_version_capture {
     description: "capture version release"
   }
   command <<<
-    Workflow_Version="v2-2-0"
+    Workflow_Version="v2-3-0"
     ~{default='' 'export TZ=' + timezone}
     date +"%Y-%m-%d" > TODAY
     echo "$Workflow_Version" > WORKFLOW_VERSION

--- a/workflows/SC2_lineage_calling_and_results.wdl
+++ b/workflows/SC2_lineage_calling_and_results.wdl
@@ -246,7 +246,6 @@ task results_table {
       Array[File] cov_out
       Array[File] percent_cvg_csv
       File pangolin_lineage_csv
-      File cdc_lineage_groups_json
       File nextclade_clades_csv
       File nextclade_variants_csv
       String nextclade_version

--- a/workflows/SC2_lineage_calling_and_results.wdl
+++ b/workflows/SC2_lineage_calling_and_results.wdl
@@ -15,7 +15,7 @@ workflow SC2_lineage_calling_and_results {
         Array[File] terra_data_table_path_array
 
         # workspace data
-        File cdc_lineage_groups_json
+        # File cdc_lineage_groups_json
         
         # python scripts
         File nextclade_json_parser_py
@@ -65,7 +65,6 @@ workflow SC2_lineage_calling_and_results {
         cov_out = select_all(cov_out),
         percent_cvg_csv = select_all(percent_cvg_csv),
         pangolin_lineage_csv = pangolin.lineage,
-        cdc_lineage_groups_json = cdc_lineage_groups_json,
         nextclade_clades_csv = parse_nextclade.nextclade_clades_csv,
         nextclade_variants_csv = parse_nextclade.nextclade_variants_csv,
         nextclade_version = nextclade.nextclade_version,
@@ -265,7 +264,6 @@ task results_table {
         --cov_out_files "~{write_lines(cov_out)}" \
         --percent_cvg_files "~{write_lines(percent_cvg_csv)}" \
         --pangolin_lineage_csv "~{pangolin_lineage_csv}" \
-        --cdc_lineage_groups_json "~{cdc_lineage_groups_json}" \
         --nextclade_variants_csv "~{nextclade_variants_csv}" \
         --nextclade_clades_csv "~{nextclade_clades_csv}" \
         --nextclade_version "~{nextclade_version}" \


### PR DESCRIPTION
This PR closes #13 

##  Aim, context, and functionality 🎯
We wanted to move away from using the cdc_lineages.json input that had to be manually updated weekly or whenever CDC added a new aggregate lineage. To do this we used [code](https://github.com/CDPHE-bioinformatics/cloud-run-aggregate-lineages/blob/main/src/main.py) that Sam developed for reaggregating lineages and that pulls the cdc aggregated lineages directly from the [CDC variant dashboard] () URL. These changes required refactoring to the concat_seq_metrics_and_lineage_results.py script and to the lineage_calling_and_results.wdl workflow.

Additionally while re-factorig the concat_seq_metrics_and_lineage_results.py script, we added function descriptions for all functions. 

I added all files required to test the concat_seq_metrics_and_lineage_results.py script locally from the command line. This greatly speeds up testing instead of having to run all tests on terra. -- As a team we discussed excluding these test files from the repo so they were removed and the commit history removed.

## Workflow Changes ✅
#### Upstream effects 
(e.g. preprocessing of data)
None

#### Input changes 
(e.g. file changes, names of data fields, etc.)

From the lineage_calling_and_results.wdl workflow: 
  - cdc_lineage_groups_json input has been removed. It is no longer need in the workspace data. 

#### Output changes 
(e.g. file changes, names of data fields, etc.)
None

#### Downstream effects 
(e.g. BigQuery organization, file structure organization, file content organization)
None


##  Testing 🛠️
**Test dataset(s):**
- cov_2136_grid (for terra testing; pulled data directly from the bucket. 

**Test(s) performed:**
- Tested the concat_seq_metrics_and_lineage_calling.py script locally on the CLI using the test data
- Tested the entire lineage_calling_and_results.wdl workflow on terra to ensure all changes made were compatible with the wdl. Then performed TheiaValidate on the sequencing results csv files comparing percent coverage, nextclade, pangolin lineage, expanded lineage, aggregated lineage, nextclade version and pangolin lineage.  

**Results (including if the results matched the expected results):**
- CLI tested resulted in a sequencing results csv file with expected results. 
- Terra testing - One sample differed in pangolin lineage and aggregated lineage but, it seems the sample did not pass assembly during the original analysis and so there was no pangolin lineage and aggregated lineage to compare. 
- Results of TheiaValidate can be found in the seq_projects validation directory. 


## Developer Checklist 👷‍♀️ 
- [x] Prior to development, issues were discussed with the bioinformatics team members and approved
- [x] Code has been refactored to sufficiently address the issues this pull request closes
- [x] Testing was performed and the results from testing match the expected results
- [x] All code changes match our style guide
- [x] README has been updated to reflect changes - no changes were necessary
- [x] Workflow diagrams in READMEs have been updated to reflect changes - no changes were necessary

## Reviewer Checklist 🔍
- [x] Met with developer to review all changes and testing performed
- [x] Code refactoring sufficiently address the issue(s) that this pull request closes
- [x] All code meets style guide criteria
- [x] Confirm testing was sufficient (e.g. correct dataset was used for testing, results match the expected results). If not, the developer will perform additional testing which should be documented in the testing section above.
- [ ] New version release number has been decided upon (if applicable)
