### PR TITLE
Fix bug with samples not in metadata

### DIFF
--- a/tasks/version_capture_task.wdl
+++ b/tasks/version_capture_task.wdl
@@ -20,7 +20,7 @@ task workflow_version_capture {
     description: "capture version release"
   }
   command <<<
-    Workflow_Version="v2-2-0"
+    Workflow_Version="v2-2-2"
     ~{default='' 'export TZ=' + timezone}
     date +"%Y-%m-%d" > TODAY
     echo "$Workflow_Version" > WORKFLOW_VERSION


### PR DESCRIPTION
##  Aim, context, and functionality 🎯
Issue: Samples missing from the metadata file should cause the script to error, produce a file of said samples, and then exit. The file was not being produced and it was not exiting correctly, but erroring later.

Action taken: Fixed logic error that caused missing_samples.tsv to not be produced. 
Added error check for entire project not in metadata file. 

This PR closes #25.

## Workflow Changes ✅
#### Upstream effects 
None

#### Input changes 
None

#### Output changes 
None

#### Downstream effects 
None

##  Testing 🛠️
**Test dataset(s):**
All normal input files, except:
1. Metadata file with an entire project removed
2. Metadata file with some samples from a project removed
3. Metadata file with all samples.

**Test(s) performed:**
Ran script once for each test dataset listed above.

**Results (including if the results matched the expected results):**
1. Script exited as expected and output proper print statement.
2. Script exited as expected, output proper print statement, and generated expected missing_dates.tsv file.
3. Script ran as expected and produced expected output files.

## Developer Checklist 👷‍♀️ 
- [x] Prior to development, issues were discussed with the bioinformatics team members and approved
- [x] Code has been refactored to sufficiently address the issues this pull request closes
- [x] Testing was performed and the results from testing match the expected results
- [x] All code changes match our style guide
- ~~[ ] README has been updated to reflect changes~~
- ~~[ ] Workflow diagrams in READMEs have been updated to reflect changes~~

## Reviewer Checklist 🔍
- [x] Met with developer to review all changes and testing performed
- [x] Code refactoring sufficiently address the issue(s) that this pull request closes
- [x] All code meets style guide critera
- [x] Confirm testing was sufficient (e.g. correct dataset was used for testing, results match the expected results). If not, the developer will perform additional testing which should be documented in the testing section above.
- [x] New version release number has been decided upon (if applicable)
