### PR TITLE
Fix and update combined_mutations.tsv creation

### DIFF
--- a/tasks/version_capture_task.wdl
+++ b/tasks/version_capture_task.wdl
@@ -21,7 +21,7 @@ task workflow_version_capture {
   }
   command <<<
 
-    Workflow_Version="v2-3-0"
+    Workflow_Version="v2-3-1"
 
     ~{default='' 'export TZ=' + timezone}
     date +"%Y-%m-%d" > TODAY

--- a/workflows/SC2_wastewater_variant_calling.wdl
+++ b/workflows/SC2_wastewater_variant_calling.wdl
@@ -53,7 +53,8 @@ workflow SC2_wastewater_variant_calling {
         call mutations_tsv {
             input:
                 variants = variant_calling.variants,
-                sample_name = id_bam.left
+                sample_name = id_bam.left,
+                project_name = project_name
         }
     }
 
@@ -64,7 +65,7 @@ workflow SC2_wastewater_variant_calling {
 
     call combine_mutations_tsv {
         input:
-            mutations_tsv = mutations_tsv.mutations_tsv
+            mutations = mutations_tsv.mutations
     }
     
     call version_capture.workflow_version_capture as workflow_version_capture {
@@ -214,20 +215,18 @@ task freyja_demix {
 task mutations_tsv {
     input {
         String sample_name
+        String project_name
         File variants
     }
 
     command <<<
-        
-        #add a column that is filled in with the sample name
-        sed 's/$/\t~{sample_name}/' ~{variants} > ~{sample_name}_variants_temp.tsv
-
-        #cut columns needed for allele counts and frequency output and then rename the column headers
-        awk '{print($20,"\t",$1,"\t",$2,"\t",$3,"\t",$4,"\t",$5,"\t",$7,"\t",$16,"\t",$17,"\t",$8,"\t",$10,"\t",$18,"\t",$19,"\t",$11,"\t",$12,"\t",$13,"\t",$14,"\t",$15,"\t")}' ~{sample_name}_variants_temp.tsv | sed -e '1s/~{sample_name}/sample_name/' -e '1s/REGION/ref_genome/' -e '1s/POS/position/' -e '1s/REF/ref_nucl/' -e '1s/ALT/alt_nucl/' -e '1s/REF_DP/ref_depth/' -e '1s/REF_QUAL/ref_qual/' -e '1s/REF_CODON/ref_codon/' -e '1s/REF_AA/ref_aa/' -e '1s/ALT_DP/alt_depth/' -e '1s/ALT_QUAL/alt_qual/' -e '1s/ALT_CODON/alt_codon/' -e '1s/ALT_AA/alt_aa/' -e '1s/ALT_FREQ/alt_freq/' -e '1s/TOTAL_DP/total_depth/' -e '1s/PVAL/pval/' -e '1s/PASS/pass/' -e '1s/GFF_FEATURE/gff_feature/' > ~{sample_name}_mutations.tsv
+        #add columns with sample_name and project_name
+        paste ~{variants} <(yes ~{sample_name} | head -n $(cat ~{variants} | wc -l)) <(yes ~{project_name} | head -n $(cat ~{variants} | wc -l)) > ~{sample_name}_mutations.tsv
+        sed -i -e '1s/~{sample_name}/sample_name/' -e '1s/~{project_name}/project_name/' ~{sample_name}_mutations.tsv
     >>>
 
     output {
-        File mutations_tsv = "${sample_name}_mutations.tsv"
+        File mutations = "${sample_name}_mutations.tsv"
     }
 
     runtime {
@@ -265,13 +264,13 @@ task freyja_aggregate {
 
 task combine_mutations_tsv {
     input {
-        Array[File] mutations_tsv
+        Array[File] mutations
     }
 
     command <<<
         
         # combine the coutns and frequency files for all samples into one
-        awk 'FNR==1 && NR!=1{next;}{print}' ~{sep=' ' mutations_tsv} >> combined_mutations.tsv
+        awk 'FNR==1 && NR!=1{next;}{print}' ~{sep=' ' mutations} >> combined_mutations.tsv
     
     >>>
 

--- a/workflows/SC2_wastewater_variant_calling.wdl
+++ b/workflows/SC2_wastewater_variant_calling.wdl
@@ -222,7 +222,7 @@ task mutations_tsv {
     command <<<
         #add columns with sample_name and project_name
         paste ~{variants} <(yes ~{sample_name} | head -n $(cat ~{variants} | wc -l)) <(yes ~{project_name} | head -n $(cat ~{variants} | wc -l)) > ~{sample_name}_mutations.tsv
-        sed -i -e '1s/~{sample_name}/sample_name/' -e '1s/~{project_name}/project_name/' ~{sample_name}_mutations.tsv
+        sed -i -e '1s/REGION/ref_genome/' -e '1s/POS/position/' -e '1s/REF/ref_nucl/' -e '1s/ALT/alt_nucl/' -e '1s/REF_DP/ref_depth/' -e '1s/REF_QUAL/ref_qual/' -e '1s/REF_CODON/ref_codon/' -e '1s/REF_AA/ref_aa/' -e '1s/ALT_DP/alt_depth/' -e '1s/ALT_QUAL/alt_qual/' -e '1s/ALT_CODON/alt_codon/' -e '1s/ALT_AA/alt_aa/' -e '1s/ALT_FREQ/alt_freq/' -e '1s/TOTAL_DP/total_depth/' -e '1s/PVAL/pval/' -e '1s/PASS/pass/' -e '1s/GFF_FEATURE/gff_feature/' -e '1s/~{sample_name}/sample_name/' -e '1s/~{project_name}/project_name/' ~{sample_name}_mutations.tsv
     >>>
 
     output {


### PR DESCRIPTION
This PR closes #32.

##  Aim, context, and functionality 🎯
Removed awk command that reorders columns as this isn't necessary. 
Removed sed command that adds column with `sample_name` and replaced with paste and sed commands to add both `sample_name` and `project_name`.
Changed `mutations_tsv` variable name to `mutations` due to name clash with task.

## Workflow Changes ✅
#### Upstream effects 
None

#### Input changes 
None

#### Output changes 
Files produced and their names stayed the same. The `combined_mutations.tsv` file is now a true tsv file without additional whitespace between columns.

#### Downstream effects 
No effects with our current setup. One note is that the column name re-ordering was removed so if that is hardcoded in a downstream analysis, that needs to be updated. Column order is not hardcoded in novel mutations.

##  Testing 🛠️
**Test dataset(s):**
NEXSEQ_WWT001, which had just been run through the workflow on the production workspace.

**Test(s) performed:**
Ran the new version of the workflow.

**Results (including if the results matched the expected results):**
Confirmed that the output `combined_mutations.tsv` file was produced as expected.

## Developer Checklist 👷‍♀️ 
- ~~[ ] Prior to development, issues were discussed with the bioinformatics team members and approved~~ very quick fix, not needed
- [x] Code has been refactored to sufficiently address the issues this pull request closes
- [x] Testing was performed and the results from testing match the expected results
- [x] All code changes match our style guide
- ~~[ ] README has been updated to reflect changes~~ not needed
- ~~[ ] Workflow diagrams in READMEs have been updated to reflect changes~~ not needed

## Reviewer Checklist 🔍
- ~~[ ] Met with developer to review all changes and testing performed~~ quick bug fix, not needed
- [x] Code refactoring sufficiently address the issue(s) that this pull request closes
- [x] All code meets style guide critera
- [x] Confirm testing was sufficient (e.g. correct dataset was used for testing, results match the expected results). If not, the developer will perform additional testing which should be documented in the testing section above.
- [x] New version release number has been decided upon (if applicable)
