### PR TITLE
Patch level bug fixes for auto versioning, NAs, and nextclade empty file failure

### DIFF
--- a/scripts/concat_seq_metrics_and_lineage_results.py
+++ b/scripts/concat_seq_metrics_and_lineage_results.py
@@ -435,6 +435,11 @@ def generate_cdc_groupings_df (cdc_groupings, pango_alias_key):
     '''
     cdc_groupings_df = pd.DataFrame(cdc_groupings)
     cdc_groupings_df = cdc_groupings_df.rename(columns={'variant': 'lineage'})
+
+    # only include lineages in the CDC datset that exist in the PANGO dataset
+    valid_aliases = pango_alias_key.keys()
+    cdc_groupings_df = cdc_groupings_df[cdc_groupings_df['lineage'].isin(valid_aliases)]
+
     cdc_groupings_df['expanded_lineage'] = cdc_groupings_df['lineage'] \
         .apply(expand_lineage, alias_key=pango_alias_key)
 

--- a/scripts/concat_seq_metrics_and_lineage_results.py
+++ b/scripts/concat_seq_metrics_and_lineage_results.py
@@ -438,7 +438,9 @@ def generate_cdc_groupings_df (cdc_groupings, pango_alias_key):
 
     # only include lineages in the CDC datset that exist in the PANGO dataset
     valid_aliases = pango_alias_key.keys()
-    cdc_groupings_df = cdc_groupings_df[cdc_groupings_df['lineage'].isin(valid_aliases)]
+    cdc_groupings_df = cdc_groupings_df[
+        cdc_groupings_df['lineage'].str.split('.').str[0].isin(valid_aliases)
+    ]
 
     cdc_groupings_df['expanded_lineage'] = cdc_groupings_df['lineage'] \
         .apply(expand_lineage, alias_key=pango_alias_key)

--- a/scripts/nextclade_json_parser.py
+++ b/scripts/nextclade_json_parser.py
@@ -156,7 +156,8 @@ def extract_variant_list(json_path, project_name, workflow_version):
     try:
         df['hsn'] = df.apply(lambda x:hsn_from_id(x.sample_name), axis = 1)
     except ValueError:
-        df['hsn'] = None    
+        df['hsn'] = None 
+    df['variant_name'] = mutation_list   
     df['gene'] = gene_list
     df['codon_position'] = codon_pos_list
     df['refAA'] = refAA_list

--- a/scripts/nextclade_json_parser.py
+++ b/scripts/nextclade_json_parser.py
@@ -153,8 +153,10 @@ def extract_variant_list(json_path, project_name, workflow_version):
     df['sample_name'] = df.apply(lambda x:get_sample_name_from_fasta_header(x.fasta_header), axis = 1)
     print('')
     print(df)
-    df['hsn'] = df.apply(lambda x:hsn_from_id(x.sample_name), axis = 1)
-    df['variant_name'] = mutation_list
+    try:
+        df['hsn'] = df.apply(lambda x:hsn_from_id(x.sample_name), axis = 1)
+    except ValueError:
+        df['hsn'] = None    
     df['gene'] = gene_list
     df['codon_position'] = codon_pos_list
     df['refAA'] = refAA_list
@@ -195,7 +197,10 @@ def get_nextclade(json_path, project_name, workflow_version):
 
     df['fasta_header'] = sample_name_list
     df['sample_name'] = df.apply(lambda x:get_sample_name_from_fasta_header(x.fasta_header), axis = 1)
-    df['hsn'] = df.apply(lambda x:hsn_from_id(x.sample_name), axis = 1)
+    try:
+        df['hsn'] = df.apply(lambda x:hsn_from_id(x.sample_name), axis = 1)
+    except ValueError:
+        df['hsn'] = None
     df['nextclade'] = clade_list
     df['total_nucleotide_mutations'] = totalSubstitutions_list
     df['total_nucleotide_deletions'] = totalDeletions_list

--- a/tasks/version_capture_task.wdl
+++ b/tasks/version_capture_task.wdl
@@ -19,7 +19,7 @@ task workflow_version_capture {
     description: "capture version release"
   }
   command <<<
-    date + "%Y-%m-%d" > TODAY
+    date "+%F" > TODAY
   >>>
   output {
     String analysis_date = read_string("TODAY")


### PR DESCRIPTION
This PR incorporates:

- #59 
- #62 
- #63 
- #65

And:

- closes #64 
- closes #61
- closes #60

##  Aim, context, and functionality 🎯

- finalize auto versioning by fixing WDL workflows
- addresses an issue with the CDC lineage grouping dataset where "NA"s were present
- addresses an issue where if there are no variants to add to the dataframe used in the function extract_variant_list, it will error when trying to create the hsn column

## Workflow Changes ✅
#### Upstream effects 

None.

#### Input changes 

None.

#### Output changes 

The workflow version will now be provided to Python scripts with underscores instead of dashes.

#### Downstream effects 

Filenames that include the version number will now have underscores instead of dashes.

##  Testing 🛠️

**Test dataset(s):**

- cov_2181_grid
- covwwt_0362_nextseq

**Test(s) performed:**

Reran test datasets using the `develop` branch in Terra.

**Results (including if the results matched the expected results):**

No issues detected.

## Developer Checklist 👷‍♀️ 
- [x] Prior to development, issues were discussed with the bioinformatics team members and approved
- [x] Code has been refactored to sufficiently address the issues this pull request closes
- [x] Testing was performed and the results from testing match the expected results
- [x] All code changes match our style guide
- [x] README has been updated to reflect changes
- [x] Workflow diagrams in READMEs have been updated to reflect changes

## Reviewer Checklist 🔍
- [ ] Met with developer to review all changes and testing performed
- [ ] Code refactoring sufficiently address the issue(s) that this pull request closes
- [ ] All code meets style guide critera
- [ ] Confirm testing was sufficient (e.g. correct dataset was used for testing, results match the expected results). If not, the developer will perform additional testing which should be documented in the testing section above.
- [x] New version release number has been decided upon (if applicable)
