### PR TITLE
Update Freyja to 1.5.2

### DIFF
--- a/workflows/SC2_wastewater_variant_calling.wdl
+++ b/workflows/SC2_wastewater_variant_calling.wdl
@@ -180,6 +180,7 @@ task freyja_demix {
         String choose_freyja_version
     }
 
+    String solver_command = if (demix_solver == '1.5.1') then '--solver ~{demix_solver}' else ''
     command <<<
         freyja --version | awk '{print $NF}' | tee VERSION
         # $NF refers to the last feild split by white spaces
@@ -192,8 +193,11 @@ task freyja_demix {
         echo -e "\t~{sample_name}\nsummarized\tLowCov\nlineages\tLowCov\nabundances\tLowCov\nresid\tLowCov\ncoverage\tLowCov" > ~{sample_name}_demixed.tsv
         
         freyja demix --eps 0.01 --covcut 10 \
-            ~{if demix_solver == '1.5.1' then '--solver ~{demix_solver}' else ''}  \
-            --barcodes ./freyja_db/usher_barcodes.csv --meta ./freyja_db/curated_lineages.json --confirmedonly ~{variants} ~{depth} --output ~{sample_name}_demixed.tsv
+            ~{solver_command}  \
+            --barcodes ./freyja_db/usher_barcodes.csv \
+            --meta ./freyja_db/curated_lineages.json \
+            --confirmedonly ~{variants} ~{depth} \
+            --output ~{sample_name}_demixed.tsv
     >>>
 
     output {

--- a/workflows/SC2_wastewater_variant_calling.wdl
+++ b/workflows/SC2_wastewater_variant_calling.wdl
@@ -24,7 +24,7 @@ workflow SC2_wastewater_variant_calling {
     }
     # secret variables
     String project_name = project_name_array[0]
-    String out_dir = out_dir_array[0]
+    String out_dir = out_dir_array[0] + demix_solver + '/'
     String outdirpath = sub(out_dir, "/$", "")
 
 

--- a/workflows/SC2_wastewater_variant_calling.wdl
+++ b/workflows/SC2_wastewater_variant_calling.wdl
@@ -317,11 +317,11 @@ task transfer_outputs {
     }
 
     command <<<
-        gsutil -m cp ~{sep=' ' variants} ~{outdirpath}/freyja/
-        gsutil -m cp ~{sep=' ' depth} ~{outdirpath}/freyja/
-        gsutil -m cp ~{sep=' ' demix} ~{outdirpath}/freyja/
-        gsutil -m cp ~{demix_aggregated} ~{outdirpath}
-        # gsutil -m cp ~{combined_mutations_tsv} ~{outdirpath}
+        gsutil -m cp ~{sep=' ' variants} ~{outdirpath}/waste_water_variant_calling/freyja/
+        gsutil -m cp ~{sep=' ' depth} ~{outdirpath}/waste_water_variant_calling/freyja/
+        gsutil -m cp ~{sep=' ' demix} ~{outdirpath}/waste_water_variant_calling/freyja/
+        gsutil -m cp ~{demix_aggregated} ~{outdirpath}/waste_water_variant_calling/
+        gsutil -m cp ~{combined_mutations_tsv} ~{outdirpath}/waste_water_variant_calling/
         gsutil -m cp ~{version_capture_wwt_variant_calling} ~{outdirpath}/summary_results/
 
         transferdate=`date`

--- a/workflows/SC2_wastewater_variant_calling.wdl
+++ b/workflows/SC2_wastewater_variant_calling.wdl
@@ -180,8 +180,8 @@ task freyja_demix {
         String choose_freyja_version
     }
 
-    String solver_command = if (demix_solver == '1.5.1') then '--solver ~{demix_solver}' else ''
-    String barcode_extension = if (demix_solver == '1.5.1') then '.feather' else '.csv'
+    String solver_command = if (choose_freyja_version == '1.5.1') then '--solver ~{demix_solver}' else ''
+    String barcode_extension = if (choose_freyja_version == '1.5.1') then '.feather' else '.csv'
 
     command <<<
         freyja --version | awk '{print $NF}' | tee VERSION

--- a/workflows/SC2_wastewater_variant_calling.wdl
+++ b/workflows/SC2_wastewater_variant_calling.wdl
@@ -181,6 +181,8 @@ task freyja_demix {
     }
 
     String solver_command = if (demix_solver == '1.5.1') then '--solver ~{demix_solver}' else ''
+    String barcode_extension = if (demix_solver == '1.5.1') then '.feather' else '.csv'
+
     command <<<
         freyja --version | awk '{print $NF}' | tee VERSION
         # $NF refers to the last feild split by white spaces
@@ -194,7 +196,7 @@ task freyja_demix {
         
         freyja demix --eps 0.01 --covcut 10 \
             ~{solver_command}  \
-            --barcodes ./freyja_db/usher_barcodes.csv \
+            --barcodes ./freyja_db/usher_barcodes~{barcode_extension} \
             --meta ./freyja_db/curated_lineages.json \
             --confirmedonly ~{variants} ~{depth} \
             --output ~{sample_name}_demixed.tsv

--- a/workflows/SC2_wastewater_variant_calling.wdl
+++ b/workflows/SC2_wastewater_variant_calling.wdl
@@ -170,12 +170,7 @@ task freyja_demix {
         String sample_name
         File variants
         File depth
-        String demix_solver
-        String choose_freyja_version
     }
-
-    String solver_command = if (choose_freyja_version == '1.5.1') then '--solver ~{demix_solver}' else ''
-    String barcode_extension = if (choose_freyja_version == '1.5.1') then '.feather' else '.csv'
 
     command <<<
         freyja --version | awk '{print $NF}' | tee VERSION

--- a/workflows/SC2_wastewater_variant_calling.wdl
+++ b/workflows/SC2_wastewater_variant_calling.wdl
@@ -19,14 +19,14 @@ workflow SC2_wastewater_variant_calling {
         # python scripts
         File version_capture_wwt_variant_calling_py
 
-        String freyja_version = '1.5.1'
+        String choose_freyja_version = '1.5.1'
         String demix_solver = 'ECOS'
     }
-    
+
     # secret variables
     String project_name = project_name_array[0]
     String out_dir = out_dir_array[0] + demix_solver + '/'
-    String outdirpath = out_dir + freyja_version + '/' + demix_solver
+    String outdirpath = out_dir + choose_freyja_version + '/' + demix_solver
 
     scatter (id_bam in zip(sample_name, trimsort_bam)) {
         call add_RG {
@@ -49,7 +49,7 @@ workflow SC2_wastewater_variant_calling {
                 depth = variant_calling.depth,
                 sample_name = id_bam.left,
                 demix_solver = demix_solver,
-                freyja_version = freyja_version
+                choose_freyja_version = choose_freyja_version
         }
         
         call mutations_tsv {
@@ -63,7 +63,7 @@ workflow SC2_wastewater_variant_calling {
     call freyja_aggregate {
         input:
             demix = freyja_demix.demix, 
-            freyja_version = freyja_version
+            choose_freyja_version = choose_freyja_version
     }
 
     call combine_mutations_tsv {
@@ -177,7 +177,7 @@ task freyja_demix {
         File variants
         File depth
         String demix_solver
-        String freyja_version
+        String choose_freyja_version
     }
 
     command <<<
@@ -200,7 +200,7 @@ task freyja_demix {
     }
 
     runtime {
-        docker: "staphb/freyja:~{freyja_version}"
+        docker: "staphb/freyja:~{choose_freyja_version}"
         memory: "32 GB"
         cpu: 8
         disks: "local-disk 200 SSD"

--- a/workflows/SC2_wastewater_variant_calling.wdl
+++ b/workflows/SC2_wastewater_variant_calling.wdl
@@ -25,8 +25,8 @@ workflow SC2_wastewater_variant_calling {
 
     # secret variables
     String project_name = project_name_array[0]
-    String out_dir = out_dir_array[0] + demix_solver + '/'
-    String outdirpath = out_dir + choose_freyja_version + '/' + demix_solver
+    String out_dir = out_dir_array[0] 
+    String outdirpath = out_dir + 'waste_water_variant_calling/' + choose_freyja_version + '/' + demix_solver
 
     scatter (id_bam in zip(sample_name, trimsort_bam)) {
         call add_RG {

--- a/workflows/SC2_wastewater_variant_calling.wdl
+++ b/workflows/SC2_wastewater_variant_calling.wdl
@@ -191,7 +191,9 @@ task freyja_demix {
         #creates a temp file with the same name as the intended output file that will get output in case of failure or overwritten in case of sucess
         echo -e "\t~{sample_name}\nsummarized\tLowCov\nlineages\tLowCov\nabundances\tLowCov\nresid\tLowCov\ncoverage\tLowCov" > ~{sample_name}_demixed.tsv
         
-        freyja demix --eps 0.01 --covcut 10 --solver ~{demix_solver} --barcodes ./freyja_db/usher_barcodes.csv --meta ./freyja_db/curated_lineages.json --confirmedonly ~{variants} ~{depth} --output ~{sample_name}_demixed.tsv
+        freyja demix --eps 0.01 --covcut 10 \
+            ~{if demix_solver == '1.5.1' then '--solver ~{demix_solver}' else ''}  \
+            --barcodes ./freyja_db/usher_barcodes.csv --meta ./freyja_db/curated_lineages.json --confirmedonly ~{variants} ~{depth} --output ~{sample_name}_demixed.tsv
     >>>
 
     output {

--- a/workflows/SC2_wastewater_variant_calling.wdl
+++ b/workflows/SC2_wastewater_variant_calling.wdl
@@ -236,6 +236,7 @@ task mutations_tsv {
 task freyja_aggregate {
     input {
         Array[File] demix
+        String choose_freyja_version
     }
 
     command <<<
@@ -249,7 +250,7 @@ task freyja_aggregate {
     }
 
     runtime {
-        docker: "staphb/freyja:~{freyja_version}"
+        docker: "staphb/freyja:~{choose_freyja_version}"
         memory: "32 GB"
         cpu: 8
         disks: "local-disk 200 SSD"

--- a/workflows/SC2_wastewater_variant_calling.wdl
+++ b/workflows/SC2_wastewater_variant_calling.wdl
@@ -326,7 +326,7 @@ task transfer_outputs {
         gsutil -m cp ~{sep=' ' depth} ~{outdirpath}/freyja/
         gsutil -m cp ~{sep=' ' demix} ~{outdirpath}/freyja/
         gsutil -m cp ~{demix_aggregated} ~{outdirpath}
-        gsutil -m cp ~{combined_mutations_tsv} ~{outdirpath}
+        # gsutil -m cp ~{combined_mutations_tsv} ~{outdirpath}
         gsutil -m cp ~{version_capture_wwt_variant_calling} ~{outdirpath}/summary_results/
 
         transferdate=`date`


### PR DESCRIPTION
This PR closes #21.

## Aim, context, and functionality 🎯
This PR updates Freyja to 1.5.2. It included comparing the new `freyja demix` solvers introduced in 1.5.1.

## Workflow Changes ✅

### Upstream Effects
None

### Input Changes

None

### Output Changes

None

### Downstream Effects

None

## Testing 🛠️

**Test dataset(s):**
covwwt_0360_nextseq

**Test(s) performed:**
1.4.7 ECOS vs 1.5.1 ECOS
1.5.1 ECOS vs 1.5.1 CLARABEL

**Results (including if the results matched the expected results):**
1.5.1 had updated lineage calls as expected, while 1.4.7 did not.
1.5.1. ECOS had more freyja failures than 1.4.7 ECOS or 1.5.1 CLARABEL. Unsure why- did not investigate as we are choosing the CLARABEL solver.
All files produced were generated as expected.

## Developer Checklist 👷‍♀️

- [x] Prior to development, issues were discussed with the bioinformatics team members and approved
- [x] Code has been refactored to sufficiently address the issues this pull request closes
- [x] Testing was performed and the results from testing match the expected results
- [x] All code changes match our style guide
- ~~README has been updated to reflect changes~~
- ~~Workflow diagrams in READMEs have been updated to reflect changes~~

