### PR TITLE
Update Medaka for new basecall models and model auto-detect.

### DIFF
--- a/docs/assembly_workflow.md
+++ b/docs/assembly_workflow.md
@@ -277,7 +277,7 @@ For setting up the worklfow inputs, use the `SC2_ont_assembly-input.json` in the
 | `sample_name`              | this.{entity_name}\_id                   |
 | `scrub_reads`              | `true` or `false`                        |
 | `scrub_genome_index`       | workspace.hostile_human_t2t_hla_fa_gz (if using read scrubbing) |
-| `medaka_model`             | example: "r1041_e82_400bps_hac_v4.2.0"   |
+| `medaka_model`             | (optional, leave blank for auto-detection) example: "r1041_e82_400bps_hac_v4.2.0"   |
 | `barcode_kit`              | example: "SQK-NBD114-96"                 |
 | `version_capture_py`       | workspace.version_capture_py             |
 

--- a/workflows/SC2_ont_assembly.wdl
+++ b/workflows/SC2_ont_assembly.wdl
@@ -390,7 +390,7 @@ task Medaka {
         memory: "16 GB"
         cpu: 8
         disks: "local-disk 100 SSD"
-        bootDiskSizeGb: 15
+        bootDiskSizeGb: 15  # Since Terra allocating 0 GB for docker container for some reason
         preemptible: 0
     }
 }

--- a/workflows/SC2_ont_assembly.wdl
+++ b/workflows/SC2_ont_assembly.wdl
@@ -389,7 +389,7 @@ task Medaka {
         docker: docker
         memory: "16 GB"
         cpu: 8
-        disks: "local-disk 100 SSD"
+        disks: "local-disk 200 SSD"
         preemptible: 0
     }
 }

--- a/workflows/SC2_ont_assembly.wdl
+++ b/workflows/SC2_ont_assembly.wdl
@@ -354,7 +354,7 @@ task Medaka {
 
         artic -v > VERSION_artic
         medaka --version | tee VERSION_medaka
-        echo $model > VERSION_medaka_model
+        echo $medaka_model > VERSION_medaka_model
 
     >>>
 

--- a/workflows/SC2_ont_assembly.wdl
+++ b/workflows/SC2_ont_assembly.wdl
@@ -379,7 +379,7 @@ task Medaka {
         }
 
         VersionInfo medaka_model_version_info = object {
-            software: "medaka_model"
+            software: "medaka_model",
             docker: docker,
             version: read_string("VERSION_medaka_model")
         }

--- a/workflows/SC2_ont_assembly.wdl
+++ b/workflows/SC2_ont_assembly.wdl
@@ -389,7 +389,8 @@ task Medaka {
         docker: docker
         memory: "16 GB"
         cpu: 8
-        disks: "local-disk 200 SSD"
+        disks: "local-disk 100 SSD"
+        bootDiskSizeGb: 15
         preemptible: 0
     }
 }

--- a/workflows/SC2_ont_assembly.wdl
+++ b/workflows/SC2_ont_assembly.wdl
@@ -337,7 +337,7 @@ task Medaka {
         String medaka_model
     }
 
-    String docker = "staphb/artic:1.2.4-1.11.1"
+    String docker = "staphb/artic:v1.2.4-1.12.0"
 
     command <<<
 

--- a/workflows/SC2_ont_assembly.wdl
+++ b/workflows/SC2_ont_assembly.wdl
@@ -345,7 +345,7 @@ task Medaka {
         # Auto-detect Medaka model from FASTQ if not provided
         if [[ -z "~{medaka_model}" ]]; then
             medaka_model_path=$(medaka tools resolve_model --auto_model consensus ~{filtered_reads})
-            medaka_model=$(basename $model_path '_model.tar.gz')
+            medaka_model=$(basename $medaka_model_path '_model.tar.gz')
         else
             medaka_model="~{medaka_model}"
         fi

--- a/workflows/SC2_ont_assembly.wdl
+++ b/workflows/SC2_ont_assembly.wdl
@@ -338,7 +338,7 @@ task Medaka {
         String? medaka_model
     }
 
-    String docker = "staphb/artic:v1.2.4-1.12.0"
+    String docker = "staphb/artic:1.2.4-1.12.0"
 
     command <<<
 

--- a/workflows/SC2_ont_assembly.wdl
+++ b/workflows/SC2_ont_assembly.wdl
@@ -12,7 +12,7 @@ workflow SC2_ont_assembly {
         String    index_1_id
         String    primer_set
         String    barcode_kit
-        String    medaka_model
+        String?    medaka_model
         Boolean  scrub_reads
         File?    scrub_genome_index
         File    covid_genome
@@ -142,6 +142,7 @@ workflow SC2_ont_assembly {
         Demultiplex.guppy_version_info,
         Medaka.artic_version_info,
         Medaka.medaka_version_info,
+        Medaka.medaka_model_version_info,
         Bam_stats.samtools_version_info,
         Scaffold.pyscaf_version_info,
         get_primer_site_variants.bcftools_version_info,
@@ -334,17 +335,26 @@ task Medaka {
         String index_1_id
         String sample_name
         File filtered_reads
-        String medaka_model
+        String? medaka_model
     }
 
     String docker = "staphb/artic:v1.2.4-1.12.0"
 
     command <<<
 
-        artic minion --medaka --medaka-model ~{medaka_model} --normalise 20000 --threads 8 --read-file ~{filtered_reads} nCoV-2019 ~{sample_name}_~{index_1_id}
+        # Auto-detect Medaka model from FASTQ if not provided
+        if [[ -z "~{medaka_model}" ]]; then
+            medaka_model_path=$(medaka tools resolve_model --auto_model consensus ~{filtered_reads})
+            medaka_model=$(basename $model_path '_model.tar.gz')
+        else
+            medaka_model="~{medaka_model}"
+        fi
+
+        artic minion --medaka --medaka-model ${medaka_model} --normalise 20000 --threads 8 --read-file ~{filtered_reads} nCoV-2019 ~{sample_name}_~{index_1_id}
 
         artic -v > VERSION_artic
         medaka --version | tee VERSION_medaka
+        echo $model > VERSION_medaka_model
 
     >>>
 
@@ -366,6 +376,12 @@ task Medaka {
             software: "medaka",
             docker: docker,
             version: read_string("VERSION_medaka")
+        }
+
+        VersionInfo medaka_model_version_info = object {
+            software: "medaka_model"
+            docker: docker,
+            version: read_string("VERSION_medaka_model")
         }
     }
 

--- a/workflows/SC2_ont_assembly.wdl
+++ b/workflows/SC2_ont_assembly.wdl
@@ -75,6 +75,7 @@ workflow SC2_ont_assembly {
     call Medaka{
         input:
             filtered_reads = select_first([Read_Filtering.guppyplex_fastq, Scrubbed_Read_Filtering.guppyplex_fastq]),
+            fastq_file = Demultiplex.guppy_demux_fastq[0],
             sample_name = sample_name,
             index_1_id = index_1_id,
             medaka_model = medaka_model
@@ -335,6 +336,7 @@ task Medaka {
         String index_1_id
         String sample_name
         File filtered_reads
+        File fastq_file  # need unzipped FASTQ with original header for model detection
         String? medaka_model
     }
 
@@ -344,7 +346,7 @@ task Medaka {
 
         # Auto-detect Medaka model from FASTQ if not provided
         if [[ -z "~{medaka_model}" ]]; then
-            medaka_model_path=$(medaka tools resolve_model --auto_model consensus ~{filtered_reads})
+            medaka_model_path=$(medaka tools resolve_model --auto_model consensus ~{fastq_file})
             medaka_model=$(basename $medaka_model_path '_model.tar.gz')
         else
             medaka_model="~{medaka_model}"


### PR DESCRIPTION
This PR closes #74

## Aim, context, and functionality 🎯

This PR updates the `staphb/artic` Docker image version from `1.2.4-1.11.1` to `1.2.4-1.12.0` in the `Medaka` task in the ONT assembly workflow to handle the most recent basecaller/medaka models. The medaka model can now be auto-detected from the FASTQ. I decided to keep `medaka_model` as an optional input because some FASTQ may not have model information in the headers (for example downloaded from SRA).

## Workflow Changes ✅

### Upstream Effects

None

### Input Changes

`medaka_model` is optional and should generally be blank to allow auto detection (avoids using the wrong model).

### Output Changes

The assembly version capture file has a new row recording `medaka_model` version.

### Downstream Effects

- [ ] @danpolanco: Update affected BigQuery data transfers

## Testing 🛠️

test_cov_2205_grid (new basecaller version- `r1041_e82_400bps_hac_v4.3.0`)
cov_2205_grid (old basecaller version - `r1041_e82_400bps_hac_v4.2.0`)

**Test(s) performed:**

Ran test_cov_2205_grid with and without model auto-detection, checked outputs are the same, did not crash.
Ran cov_2205_grid with model auto-detection and compared summary results to previous results with TheiaValidate.


## Developer Checklist 👷‍♀️

- [x] Prior to development, issues were discussed with the bioinformatics team members and approved
- [x] Code has been refactored to sufficiently address the issues this pull request closes
- [x] Testing was performed and the results from testing match the expected results
- [x] All code changes match our style guide
- [x] README has been updated to reflect changes
- [x] Workflow diagrams in READMEs have been updated to reflect changes

## Reviewer Checklist 🔍

- [x] Met with developer to review all changes and testing performed
- [x] Code refactoring sufficiently address the issue(s) that this pull request closes
- [x] All code meets style guide critera
- [x] Confirm testing was sufficient (e.g. correct dataset was used for testing, results match the expected results). If not, the developer will perform additional testing which should be documented in the testing section above.
- [x] New version release number has been decided upon (if applicable)
